### PR TITLE
Remove js folder, fix header line-height and spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a static personal website for lucaviness.com, hosted on GitHub Pages. The site is a simple, clean portfolio/blog featuring:
 - A personal introduction and bio
-- Newsletter integration with Substack (shared with Jeremi Nuer at lucandjeremi.substack.com)
 - Flying/aviation section
 - Essay pages (currently one essay: "Re: Summer 2025")
 
@@ -20,33 +19,14 @@ This is a static personal website for lucaviness.com, hosted on GitHub Pages. Th
 ### Core Structure
 - **index.html**: Main landing page with header, newsletter section, flying section, and footer
 - **essay.html**: Template for essay posts with back navigation
-- **css/style.css**: Main stylesheet with CSS variables, mobile-responsive design, and newsletter component styles
+- **css/style.css**: Main stylesheet with CSS variables and mobile-responsive design
 - **css/essay.css**: Additional styles for essay pages
-- **js/substack.js**: Fetches and displays latest Substack post using RSS2JSON API with localStorage caching
-- **js/newsletter.js**: Custom newsletter subscription component using iframe method to bypass CORS with Substack API
-
-### Key Components
-
-#### Newsletter Subscription System
-The newsletter component (js/newsletter.js) is a vanilla JavaScript class-based component that:
-- Creates subscription forms for both main content and footer
-- Uses a hidden iframe submission method to bypass CORS restrictions when calling Substack API
-- Implements form validation, loading states, and success/error messaging
-- Handles both `#newsletter-subscription` and `#footer-newsletter-subscription` containers
-
-#### Substack Integration
-The substack.js module:
-- Fetches latest post from lucandjeremi.substack.com RSS feed via rss2json.com API
-- Implements localStorage caching to reduce API calls and improve performance
-- Compares publication dates to determine if cache should be updated
-- Displays post title, link, and formatted date (MM/DD format)
 
 ### Design System
 - All text uses uniform 1rem font size (including headings)
 - Bold/heading text uses #000000, body text uses #6a6a6a
 - CSS variables defined in :root for colors, spacing, typography, and layout
 - Mobile-first responsive design with breakpoints at 768px and 480px
-- Newsletter components use gray button styling (#f0f0f0) with hover states
 - **Always use sharp corners (border-radius: 0)** — no rounded corners anywhere on the site
 
 ## Development Workflow
@@ -55,12 +35,6 @@ The substack.js module:
 Since this is a static site, simply:
 1. Open index.html or essay.html directly in a browser, or
 2. Run a local server: `python3 -m http.server 8000` or `npx serve`
-
-### Testing Newsletter Integration
-Use the debug function in browser console:
-```javascript
-window.testNewsletterAPI("test@example.com")
-```
 
 ### Deployment
 The site is hosted on GitHub Pages:
@@ -75,8 +49,6 @@ The site is hosted on GitHub Pages:
 
 ## Important Notes
 
-- No package.json or build tools - this is pure HTML/CSS/JS
-- The Substack API endpoint (lucandjeremi.substack.com/api/v1/free) is accessed via iframe form submission to avoid CORS issues
-- RSS feed is accessed via rss2json.com proxy to avoid CORS restrictions
+- No package.json or build tools - this is pure HTML/CSS
 - Static assets are in the files/ directory (favicon, images)
 - All external links use target="_blank" with rel="noopener noreferrer" for security

--- a/css/style.css
+++ b/css/style.css
@@ -79,9 +79,9 @@ header {
 header h1 {
   font-size: 1rem;
   color: var(--color-text);
-  margin-bottom: var(--spacing-sm);
+  margin-bottom: 0.4rem;
   font-weight: bold;
-  line-height: 1.2;
+  line-height: var(--line-height-base);
 }
 
 


### PR DESCRIPTION
## Summary
- Removed empty `js/` folder and all stale newsletter/Substack references from CLAUDE.md
- Fixed header `line-height` to match body (1.6) so text selection highlight is consistent
- Reduced `h1` `margin-bottom` from 0.75rem to 0.4rem to compensate for the taller line-height

## Test plan
- [ ] Visual check: selection highlight on "Luca Caviness" matches body text height
- [ ] Visual check: spacing between name and bio looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)